### PR TITLE
Makefile: Fix nproc call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:	build
 GCC_REV=$(shell svn info --show-item revision gcc4 | sed -e 's/ //g')
 CONTAINER_TAG=r$(GCC_REV)
 CONTAINER_NAME=riscosdotinfo/riscos-gccsdk-4.7
-NUMPROC?=$(nproc)
+NUMPROC?=$(shell nproc)
 
 export NUMPROC
 


### PR DESCRIPTION
nproc invocation was failing with previous syntax (perhaps a macOS thing). `make -j` resulted causing the docker build to fail somewhere down the line.

Fix with `$(shell nproc)`.